### PR TITLE
Patch airflow 1.10.1

### DIFF
--- a/examples/simple_trigger.py
+++ b/examples/simple_trigger.py
@@ -3,7 +3,7 @@ from airflow.operators import TriggerMultiDagRunOperator
 from airflow.utils.dates import days_ago
 
 
-def generate_dag_run():
+def generate_dag_run(**kwargs):
     return [{'timeout': i} for i in range(10)]
 
 
@@ -25,5 +25,5 @@ gen_target_dag_run = TriggerMultiDagRunOperator(
     task_id='gen_target_dag_run',
     dag=dag,
     trigger_dag_id='common_target',
-    python_callable=generate_dag_run,
+    python_callable=generate_dag_run
 )

--- a/multi_dagrun/operators/multi_dagrun.py
+++ b/multi_dagrun/operators/multi_dagrun.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-
 from airflow import settings
 from airflow.models import DagBag
 from airflow.operators.dagrun_operator import DagRunOrder, TriggerDagRunOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.state import State
+from airflow.utils import timezone
 
 
 class TriggerMultiDagRunOperator(TriggerDagRunOperator):
@@ -31,7 +30,7 @@ class TriggerMultiDagRunOperator(TriggerDagRunOperator):
             if not isinstance(dro, DagRunOrder):
                 dro = DagRunOrder(payload=dro)
 
-            now = datetime.utcnow()
+            now = timezone.utcnow()
             if dro.run_id is None:
                 dro.run_id = 'trig__' + now.isoformat()
 

--- a/multi_dagrun/operators/multi_dagrun.py
+++ b/multi_dagrun/operators/multi_dagrun.py
@@ -11,20 +11,16 @@ class TriggerMultiDagRunOperator(TriggerDagRunOperator):
 
     @apply_defaults
     def __init__(self, op_args=None, op_kwargs=None,
-                 provide_context=None, *args, **kwargs):
+                 *args, **kwargs):
         super(TriggerMultiDagRunOperator, self).__init__(*args, **kwargs)
         self.op_args = op_args or []
         self.op_kwargs = op_kwargs or {}
-        self.provide_context = provide_context
 
     def execute(self, context):
-        if self.provide_context:
-            context.update(self.op_kwargs)
-            self.op_kwargs = context
-
+        context.update(self.op_kwargs)
         session = settings.Session()
         created_dr_ids = []
-        for dro in self.python_callable(*self.op_args, **self.op_kwargs):
+        for dro in self.python_callable(*self.op_args, **context):
             if not dro:
                 break
             if not isinstance(dro, DagRunOrder):


### PR DESCRIPTION
- removed deprecation warning by passing context always (as in triggerdagrun)
- using timezone instead of datetime