### PR TITLE
Sensor fix for multi dag run triggered multiple places within a single DagRun

### DIFF
--- a/airflow_multi_dagrun/__init__.py
+++ b/airflow_multi_dagrun/__init__.py
@@ -1,5 +1,54 @@
+from .operators import TriggerMultiDagRunOperator
+from .sensors import MultiDagRunSensor
+
 version = '2.2.0'
 
 
 class MultiDagRunPlugin:
     name = 'MultiDagRunPlugin'
+
+
+class MultiDagRunOperatorSensorPairGenerator():
+    """
+    Convience class to generate Multi DAG run operator/sensor pair that
+    utilize the same xcom key.
+    """
+    def __init__(self, dagrun_key):
+        self._dagrun_key = 'created_dagrun_key_{}'.format(dagrun_key)
+
+    def setOperatorInitParams(self, **kwargs):
+        """
+        Set TriggerMultiDagRunOperator initialization parameters.
+        """
+        if "dagrun_key" in kwargs:
+            raise ValueError(
+                "Setting dagrun_key for operator when using {} is not allowed.".format(
+                    self.__class__
+                )
+            )
+        else:
+            kwargs["dagrun_key"] = self._dagrun_key
+        self.operator_params = kwargs
+
+    def setSensorInitParams(self, **kwargs):
+        """
+        Set MultiDagRunSensor initialization parameters.
+        """
+        if "dagrun_key" in kwargs:
+            raise ValueError(
+                "Setting dagrun_key for sensor when using {} is not allowed.".format(
+                    self.__class__
+                )
+            )
+        else:
+            kwargs["dagrun_key"] = self._dagrun_key
+        self.sensor_params = kwargs
+
+    def __call__(self):
+        """
+        Get operator/sensor pair.
+        """
+        return (
+            TriggerMultiDagRunOperator(**self.operator_params),
+            MultiDagRunSensor(**self.sensor_params),
+        )

--- a/airflow_multi_dagrun/operators.py
+++ b/airflow_multi_dagrun/operators.py
@@ -51,6 +51,8 @@ class TriggerMultiDagRunOperator(TriggerDagRunOperator):
             created_dr_ids.append(dag_run.id)
             self.log.info("Created DagRun %s, %s - %s", dag_run, self.trigger_dag_id, run_id)
 
+        self.log.debug("DagRun xcom key: %s", self.dagrun_key)
+
         if created_dr_ids:
             context['ti'].xcom_push(self.dagrun_key, created_dr_ids)
         else:

--- a/airflow_multi_dagrun/operators.py
+++ b/airflow_multi_dagrun/operators.py
@@ -12,11 +12,17 @@ from airflow.utils.types import DagRunType
 class TriggerMultiDagRunOperator(TriggerDagRunOperator):
     CREATED_DAGRUN_KEY = 'created_dagrun_key'
 
-    def __init__(self, op_args=None, op_kwargs=None, python_callable=None, *args, **kwargs):
+    def __init__(
+        self, op_args=None, op_kwargs=None, python_callable=None, dagrun_key=None, *args, **kwargs
+    ):
         super(TriggerMultiDagRunOperator, self).__init__(*args, **kwargs)
         self.op_args = op_args or []
         self.op_kwargs = op_kwargs or {}
         self.python_callable = python_callable
+        if dagrun_key is None:
+            self.dagrun_key = self.CREATED_DAGRUN_KEY
+        else:
+            self.dagrun_key = dagrun_key
 
     @provide_session
     def execute(self, context: t.Dict, session=None):
@@ -46,6 +52,6 @@ class TriggerMultiDagRunOperator(TriggerDagRunOperator):
             self.log.info("Created DagRun %s, %s - %s", dag_run, self.trigger_dag_id, run_id)
 
         if created_dr_ids:
-            context['ti'].xcom_push(self.CREATED_DAGRUN_KEY, created_dr_ids)
+            context['ti'].xcom_push(self.dagrun_key, created_dr_ids)
         else:
             self.log.info("No DagRuns created")

--- a/airflow_multi_dagrun/sensors.py
+++ b/airflow_multi_dagrun/sensors.py
@@ -41,15 +41,20 @@ class MultiDagRunSensor(BaseSensorOperator):
     """
     CREATED_DAGRUN_KEY = 'created_dagrun_key'
 
-    def __init__(self, dagrun_finished_states=None, *args, **kwargs):
+    def __init__(self, dagrun_finished_states=None, dagrun_key=None, *args, **kwargs):
         super(MultiDagRunSensor, self).__init__(*args, **kwargs)
         if dagrun_finished_states is None:
             dagrun_finished_states = [State.SUCCESS, State.FAILED]
+        if dagrun_key is None:
+            self.dagrun_key = self.CREATED_DAGRUN_KEY
+        else:
+            self.dagrun_key = dagrun_key
+
         self._dagrun_finished_states = dagrun_finished_states
 
     @provide_session
     def poke(self, context, session=None):
-        xcom_key = self.CREATED_DAGRUN_KEY
+        xcom_key = self.dagrun_key
         dagrun_ids = context['ti'].xcom_pull(task_ids=None, key=xcom_key)
         if not dagrun_ids:
             return True

--- a/airflow_multi_dagrun/sensors.py
+++ b/airflow_multi_dagrun/sensors.py
@@ -55,6 +55,8 @@ class MultiDagRunSensor(BaseSensorOperator):
     @provide_session
     def poke(self, context, session=None):
         xcom_key = self.dagrun_key
+        self.log.debug("DagRun xcom key: %s", self.dagrun_key)
+
         dagrun_ids = context['ti'].xcom_pull(task_ids=None, key=xcom_key)
         if not dagrun_ids:
             return True


### PR DESCRIPTION
Currently if multiple `TriggerMultiDagRunOperator` instances are run in
parallel and then multiple `MultiDagRunSensor` wait on each of those
operators, the operator that finishes last will push the triggered
dagrun ids to xcom to the single keyand will blow away any other dagrun
ids that are present thus potentially causing multiple sensors to pull
for the same triggered DAGs.

This addresses the issue by allowing the xcom key to be overridden from
the default, and provides a convenience class.