### PR TITLE
resolve deprecation warning for airflow.api.common.experimental.trigger_dag since 2.2.4

### DIFF
--- a/airflow_multi_dagrun/operators.py
+++ b/airflow_multi_dagrun/operators.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from airflow.api.common.experimental.trigger_dag import trigger_dag
+from airflow.api.common.trigger_dag import trigger_dag
 from airflow.models import DagRun
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils import timezone

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     version=version,
     description='MultiDagRunPlugin for airflow',
     python_requires='>=3.6.0',
+    install_requires=['apache-airflow>=2.2.4'],
     author='Ihor Liubymov',
     author_email='infunt@gmail.com',
     long_description=long_description,


### PR DESCRIPTION
This change resolves the `This module is deprecated. Please use airflow.api.common.trigger_dag instead` message that appears when using this project in apache-airflow 2.2.4+.

context: https://github.com/apache/airflow/commit/6239ae91a4c8bfb05f053a61cb8386f2d63b8b3a